### PR TITLE
Adds time tracking to enrichCollection

### DIFF
--- a/src/enrichCollection.js
+++ b/src/enrichCollection.js
@@ -91,7 +91,7 @@ export const getUserMessages = (descriptions) => {
   });
 };
 
-export const getOpenAIEnrichments = async (collection, recordLimit = 20) => {
+export const getOpenAIEnrichments = async (collection, recordLimit = 15) => {
   const messages = getUserMessages(getDescriptions(collection));
   const requestsNeeded = Math.round(messages.length / recordLimit);
 

--- a/src/enrichCollection.js
+++ b/src/enrichCollection.js
@@ -135,11 +135,17 @@ const getCollection = async () => {
 if (!process.env.TEST) {
   try {
     const collection = await getCollection();
+    const startTime = Date.now();
     const enrichments = await getOpenAIEnrichments(collection);
+    const duration = Date.now() - startTime;
     try {
       if (enrichments) {
         await persistData(enrichments, dataFilePath);
+
         console.log("Open AI enrichments written to", dataFilePath);
+        console.log(
+          `\nenrichCollection completed in ${duration / 1000} seconds.\n`,
+        );
       } else {
         console.log("No error, but there was no data to write to file");
       }


### PR DESCRIPTION
After updating to a gpt-4 model, I noticed requests taking a lot longer. Running some tests on the setup to see if I can speed things up. After trying things out, realized that it's not the model that changed the time, but the number of messages per request. So played with lowering the num messages to speed it up, but at more API requests. Ended up landing in the middle.

### Results

All times in seconds. All tests from my local machine.

#### gpt-4-1106-preview, 20 messages per request

- Run 1: `73.609`
- Run 2: `69.335`
- Run 3: `70.581`
- Average: `71.175`

#### gpt-4-1106-preview, 15 messages per request

- Run 1: `48.219`
- Run 2: `50.818`
- Run 3: `49.074`
- Average: `49.37`